### PR TITLE
qt5 porting

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,5 +34,5 @@ if(COVERAGE)
 endif()
 
 rock_init()
-rock_find_qt4()
+rock_find_qt5(Core Gui Xml Widgets PrintSupport Svg)
 rock_standard_layout()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,6 @@
 find_package(Boost REQUIRED system filesystem serialization program_options)
-# For adding the qt4 resources
+
+# For adding the qt5 resources
 set(CMAKE_AUTORCC ON)
 rock_library(templ_core
     SOURCES
@@ -370,9 +371,11 @@ rock_library(templ_gui
         gui/widgets/TemporalConstraintQuantitative.hpp
     DEPS
         templ
-    DEPS_PKGCONFIG
-        QtGui
-        QtXml
+        Qt5::Gui
+        Qt5::Widgets
+        Qt5::Xml
+        Qt5::PrintSupport
+        Qt5::Svg
     UI
         gui/TemplGui.ui
         gui/dialogs/AddLocation.ui

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -234,8 +234,6 @@ rock_library(templ
         utils/PathConstructor.hpp
     DEPS
         templ_moft
-    LIBS
-        ${GECODE_LIBRARIES}
 )
 
 rock_library(templ_benchmark


### PR DESCRIPTION
@2maz this is supposed to be merged onto a branch named "feature/qt5", but i don't see github allowing to request that kind of repository change from a pull request, so that branch would have to be created beforehand.

This PR basically contains some build fixes and a port to qt5.

The gecode situation is strange, i cannot find where the configuration variables would be set, but the code seems to need it?