### PR TITLE
ci: Switch runs-on to ubuntu-20.04

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,7 @@ name: test
 on: [push]
 jobs:
   unittests:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
The build is back to being run, but it currently fails because @2maz added an #include for boost/serialization/library_version_type.hpp in knowledge_reasoning/moreorg that does not exist before ubuntu 22.04, and for some reason the review branch is used here.